### PR TITLE
Edit links in the ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@
 
 #####  Table of Contents
 
-- [ Overview](#-overview)
-- [ Features](#-features)
-- [ Extensibility](#-extensibility)
-- [ Repository Structure](#-repository-structure)
-- [ Getting Started](#-getting-started)
-    - [ Prerequisites](#-prerequisites)
-    - [ Installation](#-installation)
-    - [ Usage](#-usage)
-    - [ Tests](#-tests)
-- [ Project Roadmap](#-project-roadmap)
-- [ Contributing](#-contributing)
-- [ License](#-license)
-- [ Acknowledgments](#-acknowledgments)
+- [ Overview](#overview)
+- [ Features](#features)
+- [ Extensibility](#extensibility)
+- [ Repository Structure](#repository-structure)
+- [ Getting Started](#getting-started)
+    - [ Prerequisites](#prerequisites)
+    - [ Installation](#installation)
+    - [ Usage](#usage)
+    - [ Tests](#tests)
+- [ Project Roadmap](#project-roadmap)
+- [ Contributing](#contributing)
+- [ License](#license)
+- [ Acknowledgments](#acknowledgments)
 
 ---
 


### PR DESCRIPTION
ToC is all about links. Currently the links are `#-installation`, which doesn't target anything. The correct value is `#installation`.